### PR TITLE
Fix test plan support.

### DIFF
--- a/DataDrivenTestsFramework/TestCaseWithData.m
+++ b/DataDrivenTestsFramework/TestCaseWithData.m
@@ -17,7 +17,9 @@
 @implementation TestCaseWithData
 
 + (NSString *)suiteName {
-    return NSStringFromClass(self);
+    // Trim Swift module
+    NSArray<NSString *> *names = [NSStringFromClass(self) componentsSeparatedByString:@"."];
+    return names.lastObject;
 }
 
 + (XCTestSuite *)defaultTestSuite {


### PR DESCRIPTION
Мы хотим использовать тест-планы с разными наборами тестов, но все сейчас все тест-сюиты попадают в одну кучу. После дебага я выяснил, что NSStringFromClass дает полное имя со свифтовым модулем, и похоже из-за этого теряется магическая связь тест-сюиты с тест планом.